### PR TITLE
Static footer and header templates

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -3,6 +3,13 @@ Changelog
 
 5.4.dev0 - (unreleased)
 -----------------------
+* Feature: added a new option to themes to allow the serving of static footer
+  and header templates for situations where wkhtmltopdf would crash when pdf
+  output is over 200 pages. This option will render the templates once and then
+  serve them going forward. If this is enabled you should avoid tal conditions
+  that change from page to page.
+  [ichimdav refs #23904]
+
 
 5.3 - (2015-04-02)
 ------------------

--- a/eea/pdf/content/theme.py
+++ b/eea/pdf/content/theme.py
@@ -76,6 +76,19 @@ EditSchema = atapi.Schema((
             )
         )
     ),
+
+    atapi.BooleanField('staticFooterAndHeader',
+        schemata='default',
+        default=False,
+        widget=atapi.BooleanWidget(
+           label=_(u"Static Footer and Header"),
+           description=_(u"Enable static footer and header html pages. "
+                         u"Footer and header templates are evaluated once"
+                         u" and then served for every pdf page."
+            )
+       )
+    ),
+
     atapi.StringField('toc',
         schemata='default',
         default='pdf.toc',

--- a/eea/pdf/exportimport/exportimport.txt
+++ b/eea/pdf/exportimport/exportimport.txt
@@ -77,6 +77,7 @@ Export
       <property name="backcover">pdf.cover.back</property>
       <property name="header">pdf.header</property>
       <property name="footer">pdf.footer</property>
+      <property name="staticFooterAndHeader">False</property>
       <property name="toc">pdf.toc</property>
       <property name="toclinks">False</property>
       <property name="javascript">True</property>

--- a/eea/pdf/themes/pdfview.py
+++ b/eea/pdf/themes/pdfview.py
@@ -59,6 +59,16 @@ class Mixin(object):
         return self.context.restrictedTraverse(template, default)
 
     def staticfy(self, filename, body, suffix='.html'):
+        """ Return file path served from a temporary location
+        :param filename: Filename
+        :type filename: string
+        :param body: File content
+        :type body: string
+        :param suffix: File prefix
+        :type suffix: string
+        :return: File location
+        :rtype: string
+        """
         with tempfile.NamedTemporaryFile(
                 prefix=filename, suffix=suffix,
                 dir=TMPDIR(), delete=False) as ofile:

--- a/eea/pdf/themes/pdfview.py
+++ b/eea/pdf/themes/pdfview.py
@@ -65,6 +65,40 @@ class Mixin(object):
             ofile.write(body)
             return ofile.name
 
+    def set_template(self, name):
+        """ Set Templates
+        :param name: Template name to retrieve
+        :type name: string
+        :return: path to template, either locally from tmp or from site location
+        :rtype: string
+        """
+        _name = "_" + name
+        parent_attribute = getattr(self, _name, None)
+        if not self.theme:
+            setattr(self, _name, '')
+            return getattr(self, _name)
+
+        if parent_attribute is None:
+            template = self.getValue(name)
+            if not self.theme.staticFooterAndHeader:
+                setattr(self, _name, ('/'.join((self.context.absolute_url(),
+                                                template)) if template else ''))
+            else:
+                try:
+                    body = self.getTemplate(name)
+                    if not body:
+                        setattr(self, _name, '')
+                        return ''
+                    body = body()
+                    if isinstance(body, unicode):
+                        body = body.encode('utf-8')
+                except Exception:
+                    setattr(self, _name, '')
+                else:
+                    setattr(self, _name, self.staticfy(template or name, body))
+        return getattr(self, _name)
+
+
 class OptionsMaker(PDFOptionsMaker, Mixin):
     """ Global options maker
     """
@@ -150,38 +184,6 @@ class BodyOptionsMaker(PDFBodyOptionsMaker, Mixin):
                           if template else '')
         return self._body
 
-    def set_template(self, name):
-        """
-        :param name: Template name to retrieve
-        :type name: string
-        :return: path to template, either locally from tmp or from site location
-        :rtype: string
-        """
-        _name = "_" + name
-        parent_attribute = getattr(self, _name, None)
-        if not self.theme:
-            setattr(self, _name, '')
-            return getattr(self, _name)
-
-        if parent_attribute is None:
-            if not self.theme.staticFooterAndHeader:
-                template = self.getValue(name)
-                setattr(self, _name, ('/'.join((self.context.absolute_url(),
-                                                template)) if template else ''))
-            else:
-                try:
-                    body = self.getTemplate(name)
-                    if not body:
-                        setattr(self, _name, '')
-                        return ''
-                    body = body()
-                    if isinstance(body, unicode):
-                        body = body.encode('utf-8')
-                except Exception:
-                    setattr(self, _name, '')
-                else:
-                    setattr(self, _name, self.staticfy('pdf.' + name, body))
-        return getattr(self, _name)
 
     @property
     def header(self):

--- a/eea/pdf/themes/pdfview.py
+++ b/eea/pdf/themes/pdfview.py
@@ -150,45 +150,50 @@ class BodyOptionsMaker(PDFBodyOptionsMaker, Mixin):
                           if template else '')
         return self._body
 
-    @property
-    def header(self):
-        """ Safely get pdf.header
+    def set_template(self, name):
         """
-        if not self.theme:
-            self._header = ''
-
-        if self._header is None:
-            template = self.getValue('header')
-            self._header = ('/'.join((self.context.absolute_url(), template))
-                            if template else '')
-        return self._header
-
-    @property
-    def footer(self):
-        """ Safely get pdf.footer
+        :param name: Template name to retrieve
+        :type name: string
+        :return: path to template, either locally from tmp or from site location
+        :rtype: string
         """
-        self._footer = ''
+        _name = "_" + name
+        parent_attribute = getattr(self, _name, None)
         if not self.theme:
-            return self._footer
+            setattr(self, _name, '')
+            return getattr(self, _name)
 
-        if self._footer is None:
+        if parent_attribute is None:
             if not self.theme.staticFooterAndHeader:
-                template = self.getValue('footer')
-                self._footer = ('/'.join((self.context.absolute_url(), template))
-                                if template else '')
+                template = self.getValue(name)
+                setattr(self, _name, ('/'.join((self.context.absolute_url(),
+                                                template)) if template else ''))
             else:
                 try:
-                    body = self.getTemplate('footer')
+                    body = self.getTemplate(name)
                     if not body:
+                        setattr(self, _name, '')
                         return ''
                     body = body()
                     if isinstance(body, unicode):
                         body = body.encode('utf-8')
                 except Exception:
-                    self._footer = ''
+                    setattr(self, _name, '')
                 else:
-                    self._footer = self.staticfy('pdf.footer', body)
-        return self._footer
+                    setattr(self, _name, self.staticfy('pdf.' + name, body))
+        return getattr(self, _name)
+
+    @property
+    def header(self):
+        """ Safely get pdf.header
+        """
+        return self.set_template('header')
+
+    @property
+    def footer(self):
+        """ Safely get pdf.footer
+        """
+        return self.set_template('footer')
 
     @property
     def toc(self):


### PR DESCRIPTION
This pull request adds a new staticFooterAndHeader property for themes which if enabled will render the header and footer within a temporary file and then serve it from there for every page in order to get around wkhtmltopdf issue with outputting pdfs with many pages ( excess of 150 ).

The same thing was already happening with the toc file in order to bypass other wkhtmltopdf issues.
